### PR TITLE
Fix: Phoenix.Endpoint needs `start_link/2`.

### DIFF
--- a/lib/phoenix_pubsub_redis_z/redis_z.ex
+++ b/lib/phoenix_pubsub_redis_z/redis_z.ex
@@ -7,13 +7,17 @@ defmodule Phoenix.PubSub.RedisZ do
 
   @default_publisher_pool_size 8
 
-  @doc false
   @spec start_link(keyword) :: Supervisor.on_start()
   def start_link(options) do
     unless is_atom(options[:name]),
       do: raise(ArgumentError, message: "Should have is_atom(:name)")
 
-    name = options[:name]
+    {name, options} = pop_in(options[:name])
+    start_link(name, options)
+  end
+
+  @spec start_link(atom, keyword) :: Supervisor.on_start()
+  def start_link(name, options) do
     supervisor_name = Module.concat(name, Supervisor)
     Supervisor.start_link(__MODULE__, [name, options], name: supervisor_name)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixPubsubRedisZ.MixProject do
   def project do
     [
       app: :phoenix_pubsub_redis_z,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Fix: Phoenix.Endpoint needs `start_link/2`.

lib/phoenix/endpoint/supervisor.ex

```elixir
defp pubsub_children(_mod, conf) do
  pub_conf = conf[:pubsub]

  if adapter = pub_conf[:adapter] do
    unless pub_conf[:name] do
      raise ArgumentError, "an adapter was given to :pubsub but no :name was defined, " <>
        "please pass the :name option accordingly"
    end
    pub_conf = [fastlane: Phoenix.Channel.Server] ++ pub_conf
    [supervisor(adapter, [pub_conf[:name], pub_conf])]
  else
    []
  end
end
```